### PR TITLE
Support `ScalarNonlinearFunction`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,9 +10,9 @@ MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-Graphs = "~1.8"
-JuMP = "~1.13"
-MathOptInterface = "~1.18"
+Graphs = "1"
+JuMP = "1"
+MathOptInterface = "1"
 julia = "1"
 
 [extras]

--- a/src/identify_variables.jl
+++ b/src/identify_variables.jl
@@ -28,15 +28,6 @@ import MathOptInterface as MOI
 import MathProgIncidence: get_equality_constraints
 
 
-# TODO: This file implements functions that filter duplicates from the
-# vectors of identified variables. It may be useful at some point to
-# identify variables, preserving duplicates. This can be implemented
-# when/if there is a need.
-#
-# This may be necessary for performant identification of variables in
-# ScalarNonlinearFunction.
-
-
 """
     identify_unique_variables(constraints::Vector)::Vector{JuMP.VariableRef}
 
@@ -215,29 +206,92 @@ end
 
 Return the variables that appear in the provided MathOptInterface function.
 
+No variable will appear more than once.
+
 # Implementation
 Only `ScalarNonlinearFunction`, `ScalarQuadraticFunction`, and
 `ScalarAffineFunction` are supported. This can be changed there is demand for
-other functions. For each type of supported function, the `_get_variable_terms`
-function should be defined. Then, for the type of each term, an additional
-`identify_unique_variables` function should be implemented.
+other functions.
+These methods are implemented by first identifying all variables that
+participate in the function, then filtering out duplicate variables.
 
 """
 function identify_unique_variables(
-    fcn::MOI.ScalarNonlinearFunction
+    fcn::Union{
+        MOI.ScalarAffineFunction,
+        MOI.ScalarQuadraticFunction,
+        MOI.ScalarNonlinearFunction,
+    },
 )::Vector{MOI.VariableIndex}
     variables = _identify_variables(fcn)
     return _filter_duplicates(variables)
 end
 
+# This method is used to handle function-in-set constraints.
+function identify_unique_variables(
+    var::MOI.VariableIndex
+)::Vector{MOI.VariableIndex}
+    return [var]
+end
+
+# NOTE: We will get a MethodError if this is called with a non-vector,
+# non-Affine/Quadratic/Nonlinear function. Should probably implement
+# some default method to catch that.
+function identify_unique_variables(
+    fcn::MOI.AbstractVectorFunction
+)::Vector{MOI.VariableIndex}
+    throw(TypeError(
+        fcn,
+        Union{
+            MOI.ScalarAffineFunction,
+            MOI.ScalarQuadraticFunction,
+            MOI.ScalarNonlinearFunction,
+        },
+        typeof(fcn),
+    ))
+end
+
+"""
+    _identify_variables(fcn)::Vector{JuMP.VariableIndex}
+
+Return all variables that appear in the provided MathOptInterface function.
+
+Duplicates may be present in the resulting vector of variables.
+If there is a use case, these methods can be made public.
+
+# Implementation
+Implemented for `ScalarAffineFunction`, `ScalarQuadraticFunction`, and
+`ScalarNonlinearFunction`. Relies on an underlying _collect_variables!
+method that (potentially recursively) builds up a vector of variables
+in-place.
+
+"""
 function _identify_variables(
-    fcn::MOI.ScalarNonlinearFunction
+    fcn::Union{
+        MOI.ScalarAffineFunction,
+        MOI.ScalarQuadraticFunction,
+        MOI.ScalarNonlinearFunction,
+    },
 )::Vector{MOI.VariableIndex}
     variables = Vector{MOI.VariableIndex}()
     _collect_variables!(variables, fcn)
     return variables
 end
 
+"""
+    _collect_variables!(variables, fcn)::Vector{JuMP.VariableIndex}
+
+Add variables from `fcn` to the `variables` vector
+
+# Implementation
+Implemented for `ScalarAffineFunction`, `ScalarQuadraticFunction`, and
+`ScalarNonlinearFunction`. For affine and quadratic functions, we iterate
+over terms with the `_get_variable_terms` function. For nonlinear functions,
+we recurse until pushing a root node onto the variable stack (or hitting
+an affine/quadratic function). Methods may need to be added if more node types
+are added to `ScalarNonlinearFunction` in the future.
+
+"""
 function _collect_variables!(
     variables::Vector{MOI.VariableIndex},
     fcn::MOI.ScalarNonlinearFunction,
@@ -260,45 +314,12 @@ function _collect_variables!(
     return variables
 end
 
-# TODO: _identify_variables and identify_unique_variables can probably
-# be combined for all ScalarConstraintFunctions
-function _identify_variables(
-    fcn::Union{MOI.ScalarQuadraticFunction, MOI.ScalarAffineFunction},
-)::Vector{MOI.VariableIndex}
-    variables = Vector{MOI.VariableIndex}()
-    _collect_variables!(variables, fcn)
-    return variables
-end
-
-function identify_unique_variables(
-    fcn::Union{MOI.ScalarQuadraticFunction, MOI.ScalarAffineFunction},
-)::Vector{MOI.VariableIndex}
-    variables = _identify_variables(fcn)
-    return _filter_duplicates(variables)
-end
-
-function identify_unique_variables(
-    fcn::MOI.AbstractVectorFunction
-)::Vector{MOI.VariableIndex}
-    throw(TypeError(
-        fcn,
-        Union{MOI.ScalarQuadraticFunction, MOI.ScalarAffineFunction},
-        typeof(fcn),
-    ))
-end
-
 function _collect_variables!(
     variables::Vector{MOI.VariableIndex},
     var::MOI.VariableIndex,
 )::Vector{MOI.VariableIndex}
     push!(variables, var)
     return variables
-end
-
-function identify_unique_variables(
-    var::MOI.VariableIndex
-)::Vector{MOI.VariableIndex}
-    return [var]
 end
 
 function _collect_variables!(
@@ -308,6 +329,21 @@ function _collect_variables!(
     return variables
 end
 
+function _collect_variables!(
+    variables::Vector{MOI.VariableIndex},
+    term::MOI.ScalarAffineTerm,
+)::Vector{MOI.VariableIndex}
+    push!(variables, term.variable)
+    return variables
+end
+
+function _collect_variables!(
+    variables::Vector{MOI.VariableIndex},
+    term::MOI.ScalarQuadraticTerm,
+)::Vector{MOI.VariableIndex}
+    push!(variables, term.variable_1, term.variable_2)
+    return variables
+end
 
 """
     _get_variable_terms(fcn)
@@ -358,22 +394,6 @@ function identify_unique_variables(
     end
 end
 
-function _collect_variables!(
-    variables::Vector{MOI.VariableIndex},
-    term::MOI.ScalarAffineTerm,
-)::Vector{MOI.VariableIndex}
-    push!(variables, term.variable)
-    return variables
-end
-
-function _collect_variables!(
-    variables::Vector{MOI.VariableIndex},
-    term::MOI.ScalarQuadraticTerm,
-)::Vector{MOI.VariableIndex}
-    push!(variables, term.variable_1, term.variable_2)
-    return variables
-end
-
 """
     _filter_duplicates
 
@@ -395,7 +415,6 @@ function _filter_duplicates(
     end
     return filtered
 end
-
 
 function _filter_duplicates(
     variables::Vector{JuMP.VariableRef},

--- a/src/identify_variables.jl
+++ b/src/identify_variables.jl
@@ -358,14 +358,6 @@ function identify_unique_variables(
     end
 end
 
-#function _identify_variables(term::MOI.ScalarAffineTerm)::Vector{MOI.VariableIndex}
-#    return [term.variable]
-#end
-#
-#function _identify_variables(term::MOI.ScalarQuadraticTerm)::Vector{MOI.VariableIndex}
-#    return [term.variable_1, term.variable_2]
-#end
-
 function _collect_variables!(
     variables::Vector{MOI.VariableIndex},
     term::MOI.ScalarAffineTerm,

--- a/src/identify_variables.jl
+++ b/src/identify_variables.jl
@@ -301,24 +301,6 @@ function identify_unique_variables(
     return [var]
 end
 
-function _identify_variables(var::MOI.VariableIndex)::Vector{MOI.VariableIndex}
-    return [var]
-end
-
-# To support nodes in ScalarNonlinearFunction expression tree
-function identify_unique_variables(var::Float64)::Vector{MOI.VariableIndex}
-    return []
-end
-
-# NOTE that this redundant function could cause some overhead. It may be better
-# to type-check each arg and skip if it not a ScalarAffineFunction,
-# ScalarQuadraticFunction, or ScalarNonlinearFunction.
-function _identify_variables(var::Float64)::Vector{MOI.VariableIndex}
-    return []
-end
-
-# NOTE again that there might be some overhead with calling this no-op function,
-# compared with just skipping these arguments in the ScalarNonlinearFunction method
 function _collect_variables!(
     variables::Vector{MOI.VariableIndex},
     var::Float64,
@@ -376,13 +358,13 @@ function identify_unique_variables(
     end
 end
 
-function _identify_variables(term::MOI.ScalarAffineTerm)::Vector{MOI.VariableIndex}
-    return [term.variable]
-end
-
-function _identify_variables(term::MOI.ScalarQuadraticTerm)::Vector{MOI.VariableIndex}
-    return [term.variable_1, term.variable_2]
-end
+#function _identify_variables(term::MOI.ScalarAffineTerm)::Vector{MOI.VariableIndex}
+#    return [term.variable]
+#end
+#
+#function _identify_variables(term::MOI.ScalarQuadraticTerm)::Vector{MOI.VariableIndex}
+#    return [term.variable_1, term.variable_2]
+#end
 
 function _collect_variables!(
     variables::Vector{MOI.VariableIndex},

--- a/src/identify_variables.jl
+++ b/src/identify_variables.jl
@@ -213,11 +213,11 @@ end
 Return the variables that appear in the provided MathOptInterface function.
 
 # Implementation
-Only `ScalarQuadraticFunction` and `ScalarAffineFunction` are supported.
-This can be changed there is demand for other functions. For each type of
-supported function, the `_get_variable_terms` function should be defined.
-Then, for the type of each term, an additional `identify_unique_variables`
-function should be implemented.
+Only `ScalarNonlinearFunction`, `ScalarQuadraticFunction`, and
+`ScalarAffineFunction` are supported. This can be changed there is demand for
+other functions. For each type of supported function, the `_get_variable_terms`
+function should be defined. Then, for the type of each term, an additional
+`identify_unique_variables` function should be implemented.
 
 """
 function identify_unique_variables(

--- a/src/identify_variables.jl
+++ b/src/identify_variables.jl
@@ -207,7 +207,6 @@ function identify_unique_variables(
     return _filter_duplicates(refs)
 end
 
-
 """
     identify_unique_variables(fcn)::Vector{JuMP.VariableIndex}
 
@@ -221,6 +220,18 @@ Then, for the type of each term, an additional `identify_unique_variables`
 function should be implemented.
 
 """
+function identify_unique_variables(
+    fcn::MOI.ScalarNonlinearFunction
+)::Vector{MOI.VariableIndex}
+    variables = Vector{MOI.VariableIndex}()
+    for arg in fcn.args
+        for var in identify_unique_variables(arg)
+            push!(variables, var)
+        end
+    end
+    return _filter_duplicates(variables)
+end
+
 function identify_unique_variables(
     fcn::Union{MOI.ScalarQuadraticFunction, MOI.ScalarAffineFunction},
 )::Vector{MOI.VariableIndex}
@@ -236,8 +247,8 @@ function identify_unique_variables(
 end
 
 function identify_unique_variables(
-    fcn::T
-)::Vector{MOI.VariableIndex} where {T<:MOI.AbstractVectorFunction}
+    fcn::MOI.AbstractVectorFunction
+)::Vector{MOI.VariableIndex}
     throw(TypeError(
         fcn,
         Union{MOI.ScalarQuadraticFunction, MOI.ScalarAffineFunction},
@@ -249,6 +260,11 @@ function identify_unique_variables(
     var::MOI.VariableIndex
 )::Vector{MOI.VariableIndex}
     return [var]
+end
+
+# To support nodes in ScalarNonlinearFunction expression tree
+function identify_unique_variables(var::Float64)::Vector{MOI.VariableIndex}
+    return []
 end
 
 

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -41,8 +41,8 @@ function _test_igraph_fields(igraph, constraints, variables)
 end
 
 
-function test_construct_interface()
-    m = make_degenerate_flow_model()
+function test_construct_interface(model_function=make_degenerate_flow_model)
+    m = model_function()
     igraph = MathProgIncidence.IncidenceGraphInterface(m)
 
     variables = [
@@ -70,8 +70,8 @@ function test_construct_interface()
 end
 
 
-function test_construct_interface_rectangular()
-    m = make_degenerate_flow_model()
+function test_construct_interface_rectangular(model_function=make_degenerate_flow_model)
+    m = model_function()
     @JuMP.constraint(
         m,
         sum_flow_eqn,
@@ -105,8 +105,8 @@ function test_construct_interface_rectangular()
 end
 
 
-function test_get_adjacent_to_linear_constraint()
-    m = make_degenerate_flow_model()
+function test_get_adjacent_to_linear_constraint(model_function=make_degenerate_flow_model)
+    m = model_function()
     igraph = MathProgIncidence.IncidenceGraphInterface(m)
     con = m[:sum_comp_eqn]
     adjacent = MathProgIncidence.get_adjacent(igraph, con)
@@ -115,8 +115,8 @@ function test_get_adjacent_to_linear_constraint()
 end
 
 
-function test_get_adjacent_to_quadratic_constraint()
-    m = make_degenerate_flow_model()
+function test_get_adjacent_to_quadratic_constraint(model_function=make_degenerate_flow_model)
+    m = model_function()
     igraph = MathProgIncidence.IncidenceGraphInterface(m)
     con = m[:comp_dens_eqn][1]
     adjacent = MathProgIncidence.get_adjacent(igraph, con)
@@ -125,8 +125,8 @@ function test_get_adjacent_to_quadratic_constraint()
 end
 
 
-function test_get_adjacent_to_nonlinear_constraint()
-    m = make_degenerate_flow_model()
+function test_get_adjacent_to_nonlinear_constraint(model_function=make_degenerate_flow_model)
+    m = model_function()
     igraph = MathProgIncidence.IncidenceGraphInterface(m)
     con = m[:bulk_dens_eqn]
     adjacent = MathProgIncidence.get_adjacent(igraph, con)
@@ -135,8 +135,8 @@ function test_get_adjacent_to_nonlinear_constraint()
 end
 
 
-function test_get_adjacent_to_variable()
-    m = make_degenerate_flow_model()
+function test_get_adjacent_to_variable(model_function=make_degenerate_flow_model)
+    m = model_function()
     igraph = MathProgIncidence.IncidenceGraphInterface(m)
     var = m[:x][2]
     adjacent = MathProgIncidence.get_adjacent(igraph, var)
@@ -151,8 +151,8 @@ function test_get_adjacent_to_variable()
 end
 
 
-function test_maximum_matching()
-    m = make_degenerate_flow_model()
+function test_maximum_matching(model_function=make_degenerate_flow_model)
+    m = model_function()
     igraph = MathProgIncidence.IncidenceGraphInterface(m)
     matching = MathProgIncidence.maximum_matching(igraph)
     @test length(matching) == 7
@@ -190,8 +190,8 @@ function test_maximum_matching()
 end
 
 
-function test_dulmage_mendelsohn()
-    m = make_degenerate_flow_model()
+function test_dulmage_mendelsohn(model_function=make_degenerate_flow_model)
+    m = model_function()
     igraph = MathProgIncidence.IncidenceGraphInterface(m)
     con_dmp, var_dmp = MathProgIncidence.dulmage_mendelsohn(igraph)
     con_undercon = con_dmp.underconstrained
@@ -290,8 +290,8 @@ function test_dulmage_mendelsohn_from_constraints_and_variables()
     return
 end
 
-function test_one_connected_component_igraph()
-    m = make_degenerate_flow_model()
+function test_one_connected_component_igraph(model_function=make_degenerate_flow_model)
+    m = model_function()
     igraph = MathProgIncidence.IncidenceGraphInterface(m)
     con_comps, var_comps = MathProgIncidence.connected_components(igraph)
     @test length(var_comps) == 1
@@ -322,8 +322,8 @@ function test_multiple_connected_components_igraph()
     return
 end
 
-function test_one_connected_component_cons_vars()
-    m = make_degenerate_flow_model()
+function test_one_connected_component_cons_vars(model_function=make_degenerate_flow_model)
+    m = model_function()
     igraph = MathProgIncidence.IncidenceGraphInterface(m)
     con_dmp, var_dmp = MathProgIncidence.dulmage_mendelsohn(igraph)
     uc_var = [var_dmp.unmatched..., var_dmp.underconstrained...]
@@ -351,8 +351,8 @@ function test_one_connected_component_cons_vars()
     return
 end
 
-function test_construct_interface_active_inequalities()
-    m = make_simple_model()
+function test_construct_interface_active_inequalities(model_function=make_simple_model)
+    m = model_function()
     JuMP.set_optimizer(m, Ipopt.Optimizer)
     JuMP.optimize!(m)
 
@@ -375,8 +375,8 @@ function test_construct_interface_active_inequalities()
     return
 end
 
-function test_active_inequalities_no_solution()
-    m = make_simple_model()
+function test_active_inequalities_no_solution(model_function=make_simple_model)
+    m = model_function()
     @test_throws(JuMP.OptimizeNotCalled, igraph = MathProgIncidence.IncidenceGraphInterface(
             m, include_active_inequalities = true, tolerance = 1e-6
         )
@@ -384,8 +384,8 @@ function test_active_inequalities_no_solution()
     return
 end
 
-function test_bad_arguments()
-    m = make_simple_model()
+function test_bad_arguments(model_function=make_simple_model)
+    m = model_function()
     @test_throws(ArgumentError, igraph = MathProgIncidence.IncidenceGraphInterface(
             m, include_active_inequalities = true, include_inequality = true
         )
@@ -395,22 +395,40 @@ end
 
 @testset "interface" begin
     test_construct_interface()
+    test_construct_interface(make_degenerate_flow_model_with_ScalarNonlinearFunction)
     test_construct_interface_rectangular()
+    test_construct_interface_rectangular(make_degenerate_flow_model_with_ScalarNonlinearFunction)
     test_get_adjacent_to_linear_constraint()
+    test_get_adjacent_to_linear_constraint(make_degenerate_flow_model_with_ScalarNonlinearFunction)
     test_get_adjacent_to_quadratic_constraint()
+    test_get_adjacent_to_quadratic_constraint(make_degenerate_flow_model_with_ScalarNonlinearFunction)
     test_get_adjacent_to_nonlinear_constraint()
+    test_get_adjacent_to_nonlinear_constraint(make_degenerate_flow_model_with_ScalarNonlinearFunction)
     test_get_adjacent_to_variable()
+    test_get_adjacent_to_variable(make_degenerate_flow_model_with_ScalarNonlinearFunction)
     test_maximum_matching()
+    test_maximum_matching(make_degenerate_flow_model_with_ScalarNonlinearFunction)
     test_dulmage_mendelsohn()
+    test_dulmage_mendelsohn(make_degenerate_flow_model_with_ScalarNonlinearFunction)
+
     test_overconstrained_due_to_fixed_variable()
     test_overconstrained_due_to_including_bound()
     test_interface_from_constraints_and_variables()
     test_matching_from_constraints_and_variables()
     test_dulmage_mendelsohn_from_constraints_and_variables()
-    test_one_connected_component_igraph()
     test_multiple_connected_components_igraph()
+
+    test_one_connected_component_igraph()
+    test_one_connected_component_igraph(make_degenerate_flow_model_with_ScalarNonlinearFunction)
     test_one_connected_component_cons_vars()
+    test_one_connected_component_cons_vars(make_degenerate_flow_model_with_ScalarNonlinearFunction)
+
     test_construct_interface_active_inequalities()
+    test_construct_interface_active_inequalities(make_simple_model_with_ScalarNonlinearFunction)
+
     test_active_inequalities_no_solution()
+    test_active_inequalities_no_solution(make_simple_model_with_ScalarNonlinearFunction)
+
     test_bad_arguments()
+    test_bad_arguments(make_simple_model_with_ScalarNonlinearFunction)
 end

--- a/test/models.jl
+++ b/test/models.jl
@@ -38,11 +38,41 @@ function make_degenerate_flow_model()
     return m
 end
 
+function make_degenerate_flow_model_with_ScalarNonlinearFunction()
+    m = JuMP.Model()
+    comps = [1, 2, 3]
+    @JuMP.variable(m, x[comps], start=1/3.0)
+    @JuMP.variable(m, flow_comp[comps], start=10.0)
+    @JuMP.variable(m, flow, start=30.0)
+    @JuMP.variable(m, rho, start=1.0)
+
+    # sum_component_eqn
+    @JuMP.constraint(m, sum_comp_eqn, sum(x) == 1)
+    # component_density_eqn
+    @JuMP.constraint(m, comp_dens_eqn, x*rho .== [1.0, 1.1, 1.2])
+    # density_eqn
+    @JuMP.constraint(m, bulk_dens_eqn, 1/rho - sum(1/x[j] for j in comps) == 0)
+    # component_flow_eqn
+    @JuMP.constraint(m, comp_flow_eqn, x.*flow .== flow_comp)
+    return m
+end
+
 function make_simple_model()
     m = JuMP.Model()
     JuMP.@variable(m, x[1:3] >= 0, start = 1.0)
     JuMP.@objective(m, Min, x[1]^2 + 2*x[2]^2 + 3*x[3]^2)
     JuMP.@NLconstraint(m, eq1, x[1]^1.5 * x[2]^2 == x[3])
+    JuMP.@constraint(m, ineq1, - x[3] <= - 1.0)
+    JuMP.@constraint(m, ineq2, x[1] + 2*x[2] >= 4)
+    JuMP.@constraint(m, range1, 0 <= x[2] + x[3] <= 10)
+    return m
+end
+
+function make_simple_model_with_ScalarNonlinearFunction()
+    m = JuMP.Model()
+    JuMP.@variable(m, x[1:3] >= 0, start = 1.0)
+    JuMP.@objective(m, Min, x[1]^2 + 2*x[2]^2 + 3*x[3]^2)
+    JuMP.@constraint(m, eq1, x[1]^1.5 * x[2]^2 == x[3])
     JuMP.@constraint(m, ineq1, - x[3] <= - 1.0)
     JuMP.@constraint(m, ineq2, x[1] + 2*x[2] >= 4)
     JuMP.@constraint(m, range1, 0 <= x[2] + x[3] <= 10)


### PR DESCRIPTION
This PR still needs:
- [x] Tests 
- [x] ~~Updates to examples/readme~~ Since the README is always public, and the documentation is for the current main branch, I'll defer these until a release, as I don't want the docs to diverge from the latest release.
- [x] Update to JuMP version in compat
- [x] https://github.com/jump-dev/JuMP.jl/pull/3106 to get merged
- [x] ~~Possibly documentation that `identify_unique_variables` supports `Float64` (to handle arbitrary nodes in `ScalarNonlinearFunction`)~~ Marking as complete as `identify_unique_variables` no longer has to support `Float64`
- [x] Benchmarks on pglib instances (e.g. #8) with https://github.com/lanl-ansi/PowerModels.jl/pull/858 to make sure performance is not heavily affected