### PR TITLE
Unpin dependency versions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -10,9 +10,8 @@ MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 
 [compat]
-Graphs = "~1.8"
-JuMP = "~1.13"
-MathOptInterface = "~1.18"
+Graphs = "1"
+JuMP = "1"
 julia = "1"
 
 [extras]


### PR DESCRIPTION
- Remove MathOptInterface from compat. We will just use whatever version JuMP requires
- Unpin Graphs and JuMP; accept 1.X