### PR TITLE
[WIP] Construct IncidenceGraphInterface from sparse matrix

### DIFF
--- a/src/incidence_graph.jl
+++ b/src/incidence_graph.jl
@@ -24,6 +24,7 @@ variables.
 """
 
 import JuMP
+import SparseArrays
 
 import MathProgIncidence: get_equality_constraints, identify_unique_variables
 
@@ -181,4 +182,23 @@ function get_bipartite_incidence_graph(
     # than vectors of var/con nodes, as the calling functions won't necessarily
     # have ordered vectors of constraints and variables.
     return graph, con_node_map, var_node_map
+end
+
+function get_bipartite_incidence_graph(matrix::SparseArrays.SparseMatrixCSC)
+    nrow = matrix.m
+    ncol = matrix.n
+    row_nodes = Vector(1:nrow)
+    col_nodes = Vector((nrow+1):(nrow+ncol))
+    row_node_map = Dict(zip(1:nrow, row_nodes))
+    col_node_map = Dict(zip(1:ncol, col_nodes))
+    edges = Tuple{Int, Int}[]
+    for i in 1:matrix.n
+        colstart = matrix.colptr[i]
+        colend = matrix.colptr[i+1] - 1
+        for j in matrix.rowval[colstart:colend]
+            push!(edges, (i + matrix.m, j))
+        end
+    end
+    graph = (row_nodes, col_nodes, edges)
+    return graph, row_node_map, col_node_map
 end

--- a/src/interface.jl
+++ b/src/interface.jl
@@ -27,6 +27,7 @@ import JuMP
 import MathProgIncidence: get_bipartite_incidence_graph, maximum_matching, GraphDataTuple
 
 import Graphs
+import SparseArrays
 
 """
 Utility function to convert a tuple of nodes and edges into a
@@ -147,6 +148,13 @@ IncidenceGraphInterface(
     get_bipartite_incidence_graph(constraints, variables)
 )
 
+function IncidenceGraphInterface(matrix::SparseArrays.SparseMatrixCSC)
+    graph, row_node_map, col_node_map = get_bipartite_incidence_graph(matrix)
+    graph = _tuple_to_graphs_jl(graph)
+    nodes = _maps_to_nodes(row_node_map, col_node_map)
+    return IncidenceGraphInterface(graph, row_node_map, col_node_map, nodes)
+end
+
 """
     get_adjacent(
         igraph::IncidenceGraphInterface,
@@ -245,7 +253,7 @@ Dict{ConstraintRef, VariableRef} with 2 entries:
 """
 function maximum_matching(
     igraph::IncidenceGraphInterface
-)::Dict{JuMP.ConstraintRef, JuMP.VariableRef}
+)
     ncon = length(igraph._con_node_map)
     nodes = igraph._nodes
     con_node_set = Set(1:ncon) # Relying on graph convention here.
@@ -381,7 +389,7 @@ julia> # As there are no unmatched constraints, the overconstrained subsystem is
 """
 function dulmage_mendelsohn(
     igraph::IncidenceGraphInterface
-)::Tuple{DMConPartition, DMVarPartition}
+)
     ncon = length(igraph._con_node_map)
     con_node_set = Set(1:ncon)
     con_dmp, var_dmp = dulmage_mendelsohn(igraph._graph, con_node_set)
@@ -454,7 +462,7 @@ julia> var_comps
 """
 function connected_components(
     igraph::IncidenceGraphInterface
-)::Tuple{Vector{Vector{JuMP.ConstraintRef}}, Vector{Vector{JuMP.VariableRef}}}
+)
     comps = Graphs.connected_components(igraph._graph)
     ncon = length(igraph._con_node_map)
     nodes = igraph._nodes
@@ -600,7 +608,7 @@ julia> MPIN.incidence_matrix(corder, vorder)
 """
 function block_triangularize(
     igraph::IncidenceGraphInterface
-)::Vector{Tuple{Vector{JuMP.ConstraintRef}, Vector{JuMP.VariableRef}}}
+)
     connodeset = Set(values(igraph._con_node_map))
     ncon = length(igraph._con_node_map)
     nvar = length(igraph._var_node_map)


### PR DESCRIPTION
- Missing tests
- This works because fields of `IncidenceGraphInterface` aren't typed
- Required me to remove types from return values of `IncidenceGraphInterface` methods for each algorithm. I could re-add them with less specificity, or use union types.